### PR TITLE
chore: cleanup node modules

### DIFF
--- a/packages/frontend/node_modules/.bin/cypress
+++ b/packages/frontend/node_modules/.bin/cypress
@@ -1,1 +1,0 @@
-../../../../node_modules/cypress/bin/cypress

--- a/packages/frontend/node_modules/.bin/terser
+++ b/packages/frontend/node_modules/.bin/terser
@@ -1,1 +1,0 @@
-../../../../node_modules/terser/bin/terser

--- a/packages/frontend/node_modules/.bin/vite
+++ b/packages/frontend/node_modules/.bin/vite
@@ -1,1 +1,0 @@
-../../../../node_modules/vite/bin/vite.js

--- a/packages/frontend/node_modules/.bin/vitest
+++ b/packages/frontend/node_modules/.bin/vitest
@@ -1,1 +1,0 @@
-../../../../node_modules/vitest/vitest.mjs


### PR DESCRIPTION
This PR cleans out the `node_modules` it must have been included at the initial commit