### PR TITLE
fix: [ALPHA-4054] Switching Wallet not Switching Accounts on App

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -15,12 +15,12 @@ import {
 import { useGetRemoteStatusQuery } from "./api/services";
 import { useAppDispatch } from "./api/store/hooks";
 import walletConnectProvider from "./api/store/providers/wallet-connect-provider";
+import { checkCookie } from "./api/utils/cookie";
 import { getRtkErrorCode } from "./api/utils/errorHandling";
 import CONFIG from "./config/config";
 import PreloaderPage from "./pages/preloader";
 import { appRoutes, loadRoutes, errorRoutes } from "./routes";
 import "@alphaday/ui-kit/global.scss";
-import { checkCookie } from "./api/utils/cookie";
 
 const landingPage = CONFIG.SEO.DOMAIN;
 const goToLandingPage = () => {


### PR DESCRIPTION
This PR addresses ALPHA-4054 by ensuring address switching from metamask also prompts proper account switch.
It also adds an error modal for cookie compilance