### PR TITLE
fix: Gas widget column alignment

### DIFF
--- a/packages/frontend/src/components/gas/Item.tsx
+++ b/packages/frontend/src/components/gas/Item.tsx
@@ -24,9 +24,9 @@ const Item: FC<IProps> = ({
     if (ethPrice && gasPrices) {
         if (type === "title") {
             return (
-                <div className="flex w-full items-center justify-between uppercase fontGroup-support text-primaryVariant100 mb-2">
-                    <span className="ml-0">{title}</span>
-                    <div className="grid grid-cols-3 gap-10 float-right">
+                <div className="uppercase fontGroup-support text-primaryVariant100 mb-2">
+                    <div className="grid grid-cols-4 md-gap-10 gap-5">
+                        <span className="ml-0">{title}</span>
                         <span className="ml-auto text-right">Fast (est.)</span>
 
                         <span className="ml-auto text-right">
@@ -39,23 +39,19 @@ const Item: FC<IProps> = ({
             );
         }
         return (
-            <div className="flex w-full items-center justify-between py-2.5 [&:last-child]:pb-0">
-                <div className="item-wrapper flex items-center">
-                    <img
-                        className="w-5 h-5 rounded-full"
-                        src={img}
-                        alt="Item"
-                    />
-                    <span className="ml-3 font-bold">{title}</span>
-                </div>
-
-                <div className="grid grid-cols-3 gap-10 min-w-[68%] float-right">
+            <div className="py-2.5 [&:last-child]:pb-0">
+                <div className="grid grid-cols-4 md-gap-10 gap-5">
+                    <div className="flex">
+                        <img
+                            className="w-5 h-5 rounded-full"
+                            src={img}
+                            alt="Item"
+                        />
+                        <span className="ml-3 font-bold">{title}</span>
+                    </div>
                     {gasPrices &&
                         Object.entries(gasPrices).map(([key, value]) => (
-                            <span
-                                key={key}
-                                className="ml-auto text-right text-primary"
-                            >
+                            <div key={key} className="text-right text-primary">
                                 {Intl.NumberFormat("en-US", {
                                     style: "currency",
                                     currency: "USD",
@@ -64,7 +60,7 @@ const Item: FC<IProps> = ({
                                         Number(value) *
                                         ethPrice.value
                                 )}
-                            </span>
+                            </div>
                         ))}
                 </div>
             </div>


### PR DESCRIPTION
This fix also simplifies the CSS by removing unnecessary classes. It should look good in most device dimensions.

# Before 
![image](https://github.com/AlphadayHQ/alphaday/assets/7271744/2151c55f-75d8-4f14-8e0d-5ce1b939e206)


# After
<img width="1428" alt="image" src="https://github.com/AlphadayHQ/alphaday/assets/7271744/e4ab86e8-8fc6-4558-b53f-c67fc08b5c5b">

<img width="437" alt="Screen Shot 2023-10-31 at 13 56 45" src="https://github.com/AlphadayHQ/alphaday/assets/7271744/bd5aa0de-4c49-4208-a937-3dd2026a4bbf">

<img width="1322" alt="Screen Shot 2023-10-31 at 13 57 46" src="https://github.com/AlphadayHQ/alphaday/assets/7271744/de17fe6d-0641-4c24-85bd-c52655a1e045">
