### PR TITLE
fix: improve adjustable toggle logic

### DIFF
--- a/packages/frontend/src/containers/calendar/CalendarContainer.tsx
+++ b/packages/frontend/src/containers/calendar/CalendarContainer.tsx
@@ -121,7 +121,6 @@ const CalendarContainer: FC<IModuleContainer<TCategoryData[][]>> = ({
     const handleCalType = useCallback(
         (calType: ECalendarType) => {
             setCalendarType(calType);
-            toggleAdjustable();
 
             dispatch(
                 setSelectedCalendarType({
@@ -130,17 +129,18 @@ const CalendarContainer: FC<IModuleContainer<TCategoryData[][]>> = ({
                 })
             );
         },
-        [dispatch, moduleData.hash, toggleAdjustable]
+        [dispatch, moduleData.hash]
     );
 
     const switchCalendarType = useCallback(() => {
         if (calendarType === ECalendarType.Month) {
             handleCalType(ECalendarType.List);
+            toggleAdjustable();
         }
         if (calendarType === ECalendarType.List) {
             handleCalType(ECalendarType.Month);
         }
-    }, [calendarType, handleCalType]);
+    }, [calendarType, handleCalType, toggleAdjustable]);
 
     const [selectedDate, setSelectedDate] = useState<Date>(storedDate);
 


### PR DESCRIPTION
While working on #96, a weird height switch bug was observed. You can test on epsilon by switching from calendar month to calendar list back and forth. You'll notice some additional space is added on calendar month (More rightly, calendar month, becomes adjustable).

This PR fixes this