### PR TITLE
enhance: Improve render logic of portfolio balance

### DIFF
--- a/packages/frontend/src/components/portfolio/PortfolioModule.tsx
+++ b/packages/frontend/src/components/portfolio/PortfolioModule.tsx
@@ -143,7 +143,7 @@ const Portfolio: FC<IPortfolio> = ({
                                         showBalance={showBalance}
                                         showAllAssets={showAllAssets}
                                         portfolioData={portfolioData}
-                                        ethPrice={undefined}
+                                        ethPrice={ethPrice}
                                         balancesQueryFailed={
                                             balancesQueryFailed
                                         }


### PR DESCRIPTION
Previously if eth price query failed the whole balance was not displayed. 

Edit:

With #102 the skeleton is kept and looks like this:

<img width="478" alt="image" src="https://github.com/AlphadayHQ/alphaday/assets/7271744/729c3e0b-82be-4a22-9d20-9f0d82f832ef">

