### PR TITLE
fix: Handle Videos not playable in Lens widgets

### DIFF
--- a/packages/frontend/src/components/feeds/LensFeedItem.tsx
+++ b/packages/frontend/src/components/feeds/LensFeedItem.tsx
@@ -144,7 +144,8 @@ const LensFeedItem: FC<TLensPost> = ({ tweet, url }) => {
                                         media.original.mimeType
                                     ) &&
                                     !media.original.url.includes("livepeer") && // TODO(elcharitas): Add support for livepeer videos
-                                    !media.original.url.includes("m3u8"); // TODO(elcharitas): Add support for m3u8 videos
+                                    !media.original.url.includes("m3u8") && // TODO(elcharitas): Add support for m3u8 videos
+                                    !media.original.url.includes("ipfs"); // TODO(elcharitas): Add support for m3u8 videos
                                 const isAudio = ALLOWED_AUDIO_TYPES.includes(
                                     media.original.mimeType
                                 );


### PR DESCRIPTION
On inspection I figured we will need to add support for m3u8 videos (a new library). And we need to support ipfs videos. I think we will need to have a general means of ipfs content (we use it in the NFT tab of the Portfolio widget) 

This PR disables support for these videos until we properly support them.