### PR TITLE
fix: Scrolling on mobile

### DIFF
--- a/packages/ui-kit/src/components/scrollbar/ScrollBar.tsx
+++ b/packages/ui-kit/src/components/scrollbar/ScrollBar.tsx
@@ -26,7 +26,7 @@ export const ScrollBar: FC<ScrollBarProps> = ({
         <div
             ref={(ref) => ref && containerRef?.(ref)}
             className={twMerge(
-                "overflow-hidden hover:overflow-y-auto scrollbar-track-backgroundVariant1800 scrollbar-thumb-primaryVariant800 scrollbar scrollbar-w-[5px] overscroll-contain h-full",
+                "overflow-hidden overflow-y-auto scrollbar-track-backgroundVariant1800 scrollbar-thumb-primaryVariant800 scrollbar scrollbar-w-[5px] overscroll-contain h-full",
                 className
             )}
             style={{ scrollbarGutter: "stable", ...style }}


### PR DESCRIPTION
The `hover` event doesn't fire on mobile and we were activating the scrollbar on hover.

By removing the `hover:` prefix we'll show scrollbar always. We may hide them  if we want to but that's a minor issue we can address later.