### PR TITLE
fix: Wallet auth issues

### DIFF
--- a/packages/frontend/src/api/hooks/useGlobalHooks.ts
+++ b/packages/frontend/src/api/hooks/useGlobalHooks.ts
@@ -19,19 +19,19 @@ export const useGlobalHooks: () => void = () => {
     );
 
     const attemptReconnect = useCallback(
-        (account: string) => {
+        (account: string, method: EWalletConnectionMethod | undefined) => {
             Logger.debug(
                 "useGlobalHooks::attemptReconnect: attempting to reconnect to the new account",
                 account
             );
             connectWallet(
-                authWallet.method ?? EWalletConnectionMethod.Metamask,
+                method ?? EWalletConnectionMethod.Metamask,
                 account.toLowerCase()
             ).catch((e) =>
                 Logger.error("useGlobalHooks::attemptReconnect: error", e)
             );
         },
-        [authWallet.method, connectWallet]
+        [connectWallet]
     );
 
     const handleAccountChange = useCallback(
@@ -56,6 +56,7 @@ export const useGlobalHooks: () => void = () => {
                     "handleAccountChange: Account switch, wallet state:",
                     authWallet
                 );
+                const { method } = authWallet;
                 if (authWallet.status === WalletConnectionState.Verified) {
                     Logger.debug(
                         "handleAccountChange: signing out...",
@@ -63,7 +64,8 @@ export const useGlobalHooks: () => void = () => {
                     );
                     signout()
                         .then(() => {
-                            attemptReconnect(account);
+                            // heads-up: after signout authWallet context is lost
+                            attemptReconnect(account, method);
                         })
                         .catch(() => ({}));
                 } else {
@@ -72,7 +74,7 @@ export const useGlobalHooks: () => void = () => {
                     );
                     cleanAuthState();
                     resetWalletConnection();
-                    attemptReconnect(account);
+                    attemptReconnect(account, method);
                 }
             }
         },

--- a/packages/frontend/src/containers/dialogs/WalletConnectionDialogContainer.tsx
+++ b/packages/frontend/src/containers/dialogs/WalletConnectionDialogContainer.tsx
@@ -107,7 +107,7 @@ const WalletConnectionDialogContainer: FC = memo(() => {
             <ErrorModal
                 size="sm"
                 errorMessage={authWallet.error}
-                isHidden={!authWallet.error}
+                isHidden={!(authWallet.status in errorPropsDict)}
                 {...errorProps}
             >
                 {errorContent}

--- a/packages/frontend/src/containers/header/profile-dropdown/ProfileDropdownContainer.tsx
+++ b/packages/frontend/src/containers/header/profile-dropdown/ProfileDropdownContainer.tsx
@@ -60,7 +60,7 @@ const ProfileDropdownContainer: FC = () => {
         <ProfileDropdownWrapper
             onConnectWallet={openWalletConnectionDialog}
             onVerifyWallet={verifyWallet}
-            onDisconnectWallet={signout}
+            onDisconnectWallet={() => signout(false)}
             isAuthenticated={isAuthenticated}
             onShowTutorial={toggleShowTutorial}
             showTutorial={showTutorial}


### PR DESCRIPTION
This PR fixes a couple of issues like:
1. Not being able to close the error dialog
1. A wagmi error trying to verify a wallet that was previously connected using metamask
1. An error when disconnecting a connected but not verified wallet