### PR TITLE
fix: Market layout on mobile

### DIFF
--- a/packages/frontend/src/components/market/CoinInfo.tsx
+++ b/packages/frontend/src/components/market/CoinInfo.tsx
@@ -11,9 +11,13 @@ const CoinInfo: FC<{
     isBookmarked: boolean;
 }> = ({ selectedMarket, isAuthenticated, onTogglePin, isBookmarked }) => (
     <div className="data-wrap">
-        <div className="flex fontGroup-normal mb-2 [&>*]:mr-1.5 [&>.bookmark]:flex [&>.bookmark]:items-center [&>.bookmark]:cursor-pointer">
+        <div className="flex fontGroup-normal mb-2 [&>*]:mr-1.5 [&>.bookmark]:flex items-center [&>.bookmark]:cursor-pointer">
             {selectedMarket.icon && (
-                <img src={selectedMarket.icon} alt="" className="w-[18px]" />
+                <img
+                    src={selectedMarket.icon}
+                    alt=""
+                    className="w-[18px] rounded-full"
+                />
             )}
             <span className="text-primary capitalize fontGroup-highlightSemi">
                 {selectedMarket.name}


### PR DESCRIPTION
# Before
<img width="398" alt="Screen Shot 2023-11-28 at 17 12 58" src="https://github.com/AlphadayHQ/alphaday/assets/7271744/b91f2912-96e8-4549-a29c-82a14c2c217e">

# After
<img width="379" alt="Screen Shot 2023-11-28 at 17 14 12" src="https://github.com/AlphadayHQ/alphaday/assets/7271744/d5134133-eda6-4d9b-b0f2-e022938b1aee">
