### PR TITLE
chore: Reset view state in storage

### DIFF
--- a/packages/frontend/src/api/store/utils.ts
+++ b/packages/frontend/src/api/store/utils.ts
@@ -1,0 +1,55 @@
+import { Logger } from "../utils/logging";
+
+/**
+ * State of widgets is typically kept in the form:
+ * someWidgetState = {
+ *     [widgetInstanceHash]: {
+ *         ...
+ *     }
+ * }
+ * This function adds a new key-value to every instance of a given widget.
+ * @param state The current widget state (for all widget instances)
+ * @param newKey
+ * @param defaultValue
+ * @returns a new widget state with the field added to each widget
+ */
+export const addFieldToWidgetState = <
+    S extends Record<string, unknown>,
+    K extends keyof S[string],
+>(
+    state: S,
+    newKey: K,
+    defaultValue: S[string][typeof newKey]
+): typeof state => {
+    const res: Record<string, unknown> = {};
+
+    Object.keys(state).forEach((widgetHash) => {
+        res[widgetHash] = {
+            ...(state[widgetHash] ?? {}),
+            [newKey]: defaultValue,
+        };
+    });
+    return res as S;
+};
+
+/**
+ * We should never have to cleanup state again. But just in case,
+ * This handler should remove an unwanted state value from the store.
+ *
+ * @param state
+ * @param fieldKey
+ */
+export const removeFieldFromState = <S extends Record<string, unknown>>(
+    state: S,
+    fieldKey: string
+): S => {
+    // remove the key from the object as well as read it's value
+    const { [fieldKey]: value, ...cleanedState } = state;
+    // we should know what has been removed to properly handle edge cases
+    Logger.debug(
+        "store::utils:removeFieldFromState, successfully removed field:value",
+        fieldKey,
+        value
+    );
+    return cleanedState as S;
+};

--- a/packages/frontend/src/config/config.ts
+++ b/packages/frontend/src/config/config.ts
@@ -84,7 +84,7 @@ const CONFIG = {
     APP: {
         VERSION: import.meta.env.VITE_VERSION || "",
         STORAGE_KEY: "alphaday",
-        STORAGE_VERSION: 100,
+        STORAGE_VERSION: 101,
         COMMIT: import.meta.env.VITE_COMMIT,
         X_APP_ID: import.meta.env.VITE_X_APP_ID || "",
         X_APP_SECRET: import.meta.env.VITE_X_APP_SECRET || "",


### PR DESCRIPTION
It looks like DB migrations like the one in https://github.com/AlphadayHQ/backend/pull/740 do not update timestamps so local data in clients won't be immediately updated.
By resetting cached views, we make sure the frontend re-fetches the data.