### PR TITLE
fix: reorder is mobile check for dev test

### DIFF
--- a/packages/frontend/src/api/hooks/useIsMobile.tsx
+++ b/packages/frontend/src/api/hooks/useIsMobile.tsx
@@ -14,18 +14,18 @@ export const useIsMobile = () => {
     const isMobileAgent = isMobile();
 
     /**
+     * If we are in dev or local, we want to show the mobile view
+     */
+    if (CONFIG.IS_DEV || CONFIG.IS_LOCAL) {
+        return width < breakpoints.TwoColMinWidth;
+    }
+
+    /**
      * If the mobile app feature flag is disabled, we don't want to
      * show the mobile view/pwa on prod
      */
     if (!isMobileEnabled) {
         return false;
-    }
-
-    /**
-     * If we are in dev or local, we want to show the mobile view
-     */
-    if (CONFIG.IS_DEV || CONFIG.IS_LOCAL) {
-        return width < breakpoints.TwoColMinWidth;
     }
 
     /**


### PR DESCRIPTION
This PR is only to aid testing on mobile using exposed ports.

Quick Tip:
With this PR, we can run `yarn dev:frontend --host` and open the IP shown: e.g 192.168.9.0:3001 on a mobile device connected to the same network to see the app.