### PR TITLE
fix: Don't overlay nav bar on modals

### DIFF
--- a/packages/ui-kit/src/mobile-components/navigation/NavBottom.tsx
+++ b/packages/ui-kit/src/mobile-components/navigation/NavBottom.tsx
@@ -63,7 +63,7 @@ const NavItem = ({ href, icon, current, name }: (typeof navigation)[0]) => (
 
 export const NavBottom = () => {
     return (
-        <div className="fixed bottom-0 left-0 z-50 w-full border-t bg-background border-borderLine">
+        <div className="fixed bottom-0 left-0 w-full border-t bg-background border-borderLine">
             <div className="grid h-full max-w-lg grid-cols-4 mx-auto">
                 {navigation.map((item) => (
                     <NavItem key={item.name} {...item} />


### PR DESCRIPTION
This is probably a temporal solution because a good fix involves re-structuring the layout and/or the navigation hierarchy.

For now it's totally fine (and maybe even the right way) to display "modal" pages over the whole screen.


<img width="376" alt="image" src="https://github.com/AlphadayHQ/alphaday/assets/7271744/66e83cf1-064f-45b1-9d1b-7f2b2388f92c">

<img width="372" alt="image" src="https://github.com/AlphadayHQ/alphaday/assets/7271744/f3e93400-5293-4221-995b-a36a6a7dc92e">
