### PR TITLE
chore: Do not auto-deploy to epsilon (skip-ci)

### DIFF
--- a/.github/workflows/deploy-epsilon.yml
+++ b/.github/workflows/deploy-epsilon.yml
@@ -1,12 +1,6 @@
 name: Deploy to epsilonday (dev)
 
 on:
-    # # deploy runs when merging on dev
-    pull_request:
-        types:
-            - closed
-        branches:
-            - dev
     # and can be triggered manually also
     workflow_dispatch:
 


### PR DESCRIPTION
Deploying to epsilon should be reserved for WIP branches and should only be done manually, if needed.