### PR TITLE
Chore: Display app info in dev mode

### DIFF
--- a/packages/frontend/src/mobile-components/profile/UserSettings.tsx
+++ b/packages/frontend/src/mobile-components/profile/UserSettings.tsx
@@ -151,8 +151,6 @@ const UserSettings: FC<IUserSettings> = ({
         },
     ];
 
-    console.log(CONFIG);
-
     return (
         <>
             <div className="mx-5 w-full">


### PR DESCRIPTION
For convenience:

<img width="376" alt="image" src="https://github.com/AlphadayHQ/alphaday/assets/7271744/7b2c3108-3f2c-49e5-bddc-596a7f1f59a6">
