### PR TITLE
chore: Do not intercept non-root routes

### DIFF
--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -22,7 +22,7 @@ export default defineConfig(({ mode }) => {
             workbox: {
                 clientsClaim: true,
                 skipWaiting: true,
-                navigateFallbackAllowlist: [/^\//],
+                navigateFallbackAllowlist: [/^\/$/],
                 maximumFileSizeToCacheInBytes: 1024 * 1024 * 4,
             },
             includeAssets: [


### PR DESCRIPTION
I've noticed that, after a new release:
- If you are on let say `/superfeed`, and you refresh, you won't see new changes
- If you are on `/`, and you refresh, you do.
This is possibly because the SW is intercepting all routes except from `/`.