### PR TITLE
fix: OPT form not centered

### DIFF
--- a/packages/frontend/src/layout/PagedMobileLayout.tsx
+++ b/packages/frontend/src/layout/PagedMobileLayout.tsx
@@ -15,7 +15,7 @@ const PagedMobileLayout: FC<{
                 handleBack={handleBack}
                 handleClose={handleClose}
             />
-            <div className="w-full flex flex-grow min-w-max">{children}</div>
+            <div className="w-full flex flex-grow flex-col">{children}</div>
         </ScrollBar>
     );
 };

--- a/packages/frontend/src/mobile-components/profile/UserSettings.tsx
+++ b/packages/frontend/src/mobile-components/profile/UserSettings.tsx
@@ -156,7 +156,7 @@ const UserSettings: FC<IUserSettings> = ({
 
     return (
         <>
-            <div className="mx-5 w-full">
+            <div className="px-5 w-full">
                 {/* <div className="flex flex-start w-full items-center mb-4">
                 <ChevronSVG
                     onClick={onClose}


### PR DESCRIPTION
The `min-w-max` property in our `PagedMobileLayout` container it's not letting the child component span the full width of the screen:
<img width="953" alt="Screenshot 2024-03-14 at 15 11 26" src="https://github.com/AlphadayHQ/alphaday/assets/7271744/78b9440c-f20d-4ba1-85db-0d93756c7d60">

Removing it would allow us to get the OTP form visually centered. However, there are side effects, namely, the sign up button in user settings, which overflows. This is because of the extra margin that was added, which should be a padding.

# Preview
<img width="375" alt="Screenshot 2024-03-14 at 15 07 40" src="https://github.com/AlphadayHQ/alphaday/assets/7271744/f2ad1fcd-8a63-4308-ae54-08d06e000bca">
