### PR TITLE
chore: Show time stamp in Price Alert Card

### DIFF
--- a/packages/frontend/src/mobile-components/feed/MarketCard.tsx
+++ b/packages/frontend/src/mobile-components/feed/MarketCard.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 import { twMerge } from "@alphaday/ui-kit";
-import { EFeedItemType, TSuperfeedItem } from "src/api/types";
+import { TSuperfeedItem } from "src/api/types";
 import { ENumberStyle, formatNumber } from "src/api/utils/format";
 import { computeDuration } from "src/utils/dateUtils";
 import { imgOnError } from "src/utils/errorHandling";


### PR DESCRIPTION
# Before
<img width="461" alt="Screenshot 2024-03-21 at 08 35 55" src="https://github.com/AlphadayHQ/alphaday/assets/39612820/c8d99286-93bc-42cf-b613-1f27ae3d5e8b">

# After 

<img width="458" alt="Screenshot 2024-03-21 at 08 35 22" src="https://github.com/AlphadayHQ/alphaday/assets/39612820/36e9a3a0-d8f9-4d65-a5f1-2ddb3e7d879e">
