### PR TITLE
fix: Handle bad setState

### DIFF
--- a/packages/frontend/src/mobile-components/profile/UserSettings.tsx
+++ b/packages/frontend/src/mobile-components/profile/UserSettings.tsx
@@ -107,7 +107,11 @@ const UserSettings: FC<IUserSettings> = ({
     const [isProfileUpdated, setIsProfileUpdated] = useState(false);
     const prevIsSavingProfile = usePrevious(isSavingProfile);
 
-    if (prevIsSavingProfile === true && isSavingProfile === false) {
+    if (
+        prevIsSavingProfile === true &&
+        isSavingProfile === false &&
+        isProfileUpdated === false
+    ) {
         setIsProfileUpdated(true);
     }
 


### PR DESCRIPTION
Moving the setState out of the effect created an infinite loop. This fixes that.