### PR TITLE
fix: Truncate filter keyword results

### DIFF
--- a/packages/frontend/src/api/hooks/useFilterKeywordSearch.ts
+++ b/packages/frontend/src/api/hooks/useFilterKeywordSearch.ts
@@ -35,26 +35,30 @@ export const useFilterKeywordSearch: () => IFilterKeywordSearch = () => {
     const keywordResults = useMemo(() => {
         if (!keywordsData) return undefined;
         return {
-            [ESupportedFilters.ConceptTags]: keywordsData.conceptTags.map(
-                (keyword) => ({
+            [ESupportedFilters.ConceptTags]: keywordsData.conceptTags
+                .slice(0, 6)
+                .map((keyword) => ({
                     id: keyword.id,
                     name: keyword.name,
                     slug: keyword.tag.slug,
                     type: ESupportedFilters.ConceptTags,
-                })
-            ),
-            [ESupportedFilters.Chains]: keywordsData.chains.map((keyword) => ({
-                id: keyword.id,
-                name: keyword.name,
-                slug: keyword.tag.slug,
-                type: ESupportedFilters.Chains,
-            })),
-            [ESupportedFilters.Coins]: keywordsData.coins.map((keyword) => ({
-                id: keyword.id,
-                name: keyword.name,
-                slug: keyword.tag.slug,
-                type: ESupportedFilters.Coins,
-            })),
+                })),
+            [ESupportedFilters.Chains]: keywordsData.chains
+                .slice(0, 6)
+                .map((keyword) => ({
+                    id: keyword.id,
+                    name: keyword.name,
+                    slug: keyword.tag.slug,
+                    type: ESupportedFilters.Chains,
+                })),
+            [ESupportedFilters.Coins]: keywordsData.coins
+                .slice(0, 6)
+                .map((keyword) => ({
+                    id: keyword.id,
+                    name: keyword.name,
+                    slug: keyword.tag.slug,
+                    type: ESupportedFilters.Coins,
+                })),
         };
     }, [keywordsData]);
 


### PR DESCRIPTION
# Before
<img width="362" alt="Screenshot 2024-03-27 at 11 12 26" src="https://github.com/AlphadayHQ/alphaday/assets/39612820/fb177631-4e24-4ae4-8016-2927ea62888a">


# After
<img width="361" alt="Screenshot 2024-03-27 at 11 11 45" src="https://github.com/AlphadayHQ/alphaday/assets/39612820/3dfb1e5a-2d5c-49a5-9f48-7dc292332f3c">
