### PR TITLE
chore(workbox): Disable dev mode

### DIFF
--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -17,8 +17,7 @@ export default defineConfig(({ mode }) => {
         VitePWA({
             registerType: "autoUpdate",
             devOptions: {
-                enabled: true,
-                type: "module",
+                enabled: false,
             },
             workbox: {
                 clientsClaim: true,


### PR DESCRIPTION
Dev mode introduces too much noise in the console and unless you are debugging something related to the pwa config, there isn't much sense in keeping it on by default.

Also, the `module` option only has sense for the `injectManifest` strategy which we don't use, so I removed it.