### PR TITLE
fix: Handle no blank page on saveViewAs

### DIFF
--- a/packages/frontend/src/api/hooks/useView.ts
+++ b/packages/frontend/src/api/hooks/useView.ts
@@ -343,7 +343,7 @@ export const useView: () => IView = () => {
                     );
                     return;
                 }
-
+                setDialogState(EViewDialogState.Closed);
                 saveViewAsMut(body)
                     .unwrap()
                     .then((response) => {
@@ -351,7 +351,6 @@ export const useView: () => IView = () => {
                             "useView::saveViewAs::saveViewAsMut: success. Response:",
                             response
                         );
-                        setDialogState(EViewDialogState.Closed);
                         setAllowEmptyView(false);
                         toast(`Created new Board: ${response.name}`, {
                             status: "alert",


### PR DESCRIPTION
So the issue i think is that `SaveViewAs` is a mutation so the local state is updated (which causes a rerender) before the dialog state is updated from Busy to Closed. Hence there is an error.