### PR TITLE
chore: Build Android in development mode

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -8,7 +8,7 @@
     "dev": "pwa-assets-generator && VITE_COMMIT=$(git rev-parse --short HEAD) VITE_COMMIT_TS=$(git log -1 --pretty='format:%cd' --date=format:'%Y-%m-%d %H:%M:%S') vite",
     "dev:ssl": "USE_SSL=true yarn dev --host --port 443",
     "build": "pwa-assets-generator && VITE_COMMIT=$(git rev-parse --short HEAD) VITE_COMMIT_TS=$(git log -1 --pretty='format:%cd' --date=format:'%Y-%m-%d %H:%M:%S') vite build",
-    "build:android": "ionic capacitor build android",
+    "build:android:dev": "ionic capacitor build android -- --mode development",
     "build:android:prod": "node env-check.cjs && ionic capacitor build android --prod",
     "platform:add": "ionic capacitor add",
     "generate-pwa-assets": "pwa-assets-generator",


### PR DESCRIPTION
Recall: When we build the Android bundle for production we must use `.env.production`. However, if you wanted to build a test build using `yarn build:android`, vite would have been run in production mode (because building always assume production mode), and `.env.production` would have been loaded.

With this command, you can build the app in development mode and thus be able to debug and see console logs.