### PR TITLE
fix: Downgrade ionic router (fixes tab switching)

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -28,7 +28,7 @@
     "@capacitor/keyboard": "5.0.8",
     "@capacitor/status-bar": "5.0.7",
     "@ionic/react": "7.8.1",
-    "@ionic/react-router": "7.8.3",
+    "@ionic/react-router": "7.8.1",
     "@react-oauth/google": "0.12.1",
     "@reduxjs/toolkit": "1.8.0",
     "@sentry/react": "7.109.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3009,21 +3009,12 @@
     ionicons "^7.2.2"
     tslib "^2.1.0"
 
-"@ionic/core@7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@ionic/core/-/core-7.8.3.tgz#4da064bc314ba6e9e19a99a6d800b62cbe2c5b9b"
-  integrity sha512-5pFoE8gbhbCuyQlZ7BlRk4+S4PmmqgkALw4IAhtUK1TuzsKJ2KLFBlp0rdlWS+VcKEyrec/ptVki8oN5335vRA==
+"@ionic/react-router@7.8.1":
+  version "7.8.1"
+  resolved "https://registry.yarnpkg.com/@ionic/react-router/-/react-router-7.8.1.tgz#4553a9a36ae364cf9f844aa099f1e40469550f8f"
+  integrity sha512-RmkucjZkMNE7OK8odL/+L9PLPINliH1uWiY9nObfwOtnyt9iXnPgs8MjxDGO3ndiTEPu+ssRLlol9GEwhxjjvw==
   dependencies:
-    "@stencil/core" "^4.12.2"
-    ionicons "^7.2.2"
-    tslib "^2.1.0"
-
-"@ionic/react-router@7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@ionic/react-router/-/react-router-7.8.3.tgz#a4031dc27fb1cbb920a9a1caa11636bcd9edc727"
-  integrity sha512-K4gGh1Xs78V6a5KeN490G0tUKUP6r+TbWqY2oqDBJiNLmjk8n4JYPVeL3I6WYWZwuFBbX01UgCXic41L9Jd86A==
-  dependencies:
-    "@ionic/react" "7.8.3"
+    "@ionic/react" "7.8.1"
     tslib "*"
 
 "@ionic/react@7.6.1":
@@ -3041,15 +3032,6 @@
   integrity sha512-MJgmlsm69lvHiPBFHSUg9ZGbWyjfn5ZDUidYSE8oWA/L0Mtd7XqNl9DMlSXWy87jaOET96R72eSwgsAPZ+FEBA==
   dependencies:
     "@ionic/core" "7.8.1"
-    ionicons "^7.0.0"
-    tslib "*"
-
-"@ionic/react@7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@ionic/react/-/react-7.8.3.tgz#8d4951b9c83aba2f6e1b7f4532c7453f2e2752fa"
-  integrity sha512-nush+Ra/KNLv4MvxODwxNe7/FVcDRyc0xgkFKwXu9P/ztUv8qqy0zotHxsJVAb9BAd/r78eBpdyaOnUQcLw2Dg==
-  dependencies:
-    "@ionic/core" "7.8.3"
     ionicons "^7.0.0"
     tslib "*"
 


### PR DESCRIPTION
It seems that after upgrading react router, at least these 2 bugs were introduced:

- switching tabs stoped working
- Navigating directly to `superfeed/search/:tags` resulted in the `superfeed/` path being displayed while the actual tags were retrieved by the superfeed container.