### PR TITLE
fix: Use custom blob for Uniswap's token list

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -68,6 +68,8 @@ jobs:
               env:
                   VITE_ENVIRONMENT: ${{ env.ENVIRONMENT }}
 
+                  VITE_STORAGE_BUCKET_URL: ${{ secrets.DEV__FRONTEND__STORAGE_BUCKET_URL }}
+
                   VITE_DEFIPULSE_API_KEY: ${{ secrets.STAGING__FRONTEND__API_KEY_DEFIPULSE }}
                   VITE_ETHERSCAN_API_KEY: ${{ secrets.STAGING__FRONTEND__API_KEY_ETHERSCAN }}
                   VITE_ETHPLORER_API_KEY: ${{ secrets.STAGING__FRONTEND__API_KEY_ETHPLORER }}

--- a/.github/workflows/deploy-epsilon.yml
+++ b/.github/workflows/deploy-epsilon.yml
@@ -57,6 +57,8 @@ jobs:
               env:
                   VITE_ENVIRONMENT: ${{ env.ENVIRONMENT }}
 
+                  VITE_STORAGE_BUCKET_URL: ${{ secrets.DEV__FRONTEND__STORAGE_BUCKET_URL }}
+
                   VITE_DEFIPULSE_API_KEY: ${{ secrets.STAGING__FRONTEND__API_KEY_DEFIPULSE }}
                   VITE_ETHERSCAN_API_KEY: ${{ secrets.STAGING__FRONTEND__API_KEY_ETHERSCAN }}
                   VITE_ETHPLORER_API_KEY: ${{ secrets.STAGING__FRONTEND__API_KEY_ETHPLORER }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -72,6 +72,8 @@ jobs:
               env:
                   VITE_ENVIRONMENT: ${{ env.ENVIRONMENT }}
 
+                  VITE_STORAGE_BUCKET_URL: ${{ secrets.PROD__FRONTEND__STORAGE_BUCKET_URL }}
+
                   VITE_DEFIPULSE_API_KEY: ${{ secrets.PROD__FRONTEND__API_KEY_DEFIPULSE }}
                   VITE_ETHERSCAN_API_KEY: ${{ secrets.PROD__FRONTEND__API_KEY_ETHERSCAN }}
                   VITE_ETHPLORER_API_KEY: ${{ secrets.PROD__FRONTEND__API_KEY_ETHPLORER }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -66,6 +66,8 @@ jobs:
               env:
                   VITE_ENVIRONMENT: ${{ env.ENVIRONMENT }}
 
+                  VITE_STORAGE_BUCKET_URL: ${{ secrets.STAGING__FRONTEND__STORAGE_BUCKET_URL }}
+
                   VITE_DEFIPULSE_API_KEY: ${{ secrets.STAGING__FRONTEND__API_KEY_DEFIPULSE }}
                   VITE_ETHERSCAN_API_KEY: ${{ secrets.STAGING__FRONTEND__API_KEY_ETHERSCAN }}
                   VITE_ETHPLORER_API_KEY: ${{ secrets.STAGING__FRONTEND__API_KEY_ETHPLORER }}

--- a/packages/frontend/.env.sample
+++ b/packages/frontend/.env.sample
@@ -13,6 +13,7 @@ VITE_ETHERSCAN_API_KEY=key
 VITE_ETHPLORER_API_KEY=key
 
 VITE_API_BASE_URL=https://api.zettaday.com/
+VITE_STORAGE_BUCKET_URL=https://s3.eu-west-1.amazonaws.com/...
 VITE_ZAPPER_BASE_URL=https://api.zapper.fi/v1/
 VITE_ZAPPER_BASE_URL_V2=https://api.zapper.fi/v2/
 VITE_COINGECKO_BASE_URL=https://api.coingecko.com/api/v3/

--- a/packages/frontend/env-check.cjs
+++ b/packages/frontend/env-check.cjs
@@ -2,16 +2,17 @@ const fs = require("fs");
 const dotenv = require("dotenv");
 
 // Load environment variables from .env file
-const envResult = dotenv.config({ path: '.env.production' });
+const envResult = dotenv.config({ path: ".env.production" });
 
 if (envResult.error) {
-    console.error('Error loading .env file:', envResult.error);
+    console.error("Error loading .env file:", envResult.error);
     process.exit(1);
 }
 
 const requiredVariables = [
     "VITE_ENVIRONMENT",
     "VITE_API_BASE_URL",
+    "VITE_STORAGE_BUCKET_URL",
     "VITE_X_APP_ID",
     "VITE_X_APP_SECRET",
     "VITE_ZAPPER_BASE_URL",
@@ -33,15 +34,20 @@ const requiredVariables = [
     "VITE_HOTJAR_SNIPPET_VERSION",
     "VITE_OAUTH_ID_GOOGLE",
     "VITE_CLARITY_PROJECT_ID",
-    "VITE_CLARITY_MOBILE_PROJECT_ID"
+    "VITE_CLARITY_MOBILE_PROJECT_ID",
 ];
 
 // Check if all required variables are set
-const missingVariables = requiredVariables.filter((variable) => !process.env[variable]);
+const missingVariables = requiredVariables.filter(
+    (variable) => !process.env[variable]
+);
 
 if (missingVariables.length > 0) {
-    console.error('Missing required environment variables:', missingVariables.join(', '));
+    console.error(
+        "Missing required environment variables:",
+        missingVariables.join(", ")
+    );
     process.exit(1);
 } else {
-    console.log('All required environment variables are set.');
+    console.log("All required environment variables are set.");
 }

--- a/packages/frontend/src/api/services/blobsApi.ts
+++ b/packages/frontend/src/api/services/blobsApi.ts
@@ -1,0 +1,30 @@
+import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+import CONFIG from "../../config/config";
+import { Logger } from "../utils/logging";
+
+const API_CONFIG = CONFIG.API.DEFAULT;
+const { BLOBS_URL } = API_CONFIG;
+
+export type TGetUniswapTokenListRequest = void;
+export type TGetUniswapTokenListResponse = string;
+
+export const blobsApi = createApi({
+    reducerPath: "blobsApi",
+    baseQuery: fetchBaseQuery({
+        baseUrl: BLOBS_URL,
+    }),
+    endpoints: (builder) => ({
+        getTokensList: builder.query<
+            TGetUniswapTokenListResponse,
+            TGetUniswapTokenListRequest
+        >({
+            query: () => {
+                const path = `${BLOBS_URL}tokens-uniswap.json`;
+                Logger.debug("getTokensList: querying", path);
+                return path;
+            },
+        }),
+    }),
+});
+
+export const { useGetTokensListQuery } = blobsApi;

--- a/packages/frontend/src/api/services/index.ts
+++ b/packages/frontend/src/api/services/index.ts
@@ -88,6 +88,8 @@ export * from "./superfeed/types";
 export * from "./alphadayApi";
 export * from "./baseTypes";
 
+export * from "./blobsApi";
+
 /**
  * third party
  */

--- a/packages/frontend/src/api/store/reducer.ts
+++ b/packages/frontend/src/api/store/reducer.ts
@@ -1,5 +1,11 @@
 import { combineReducers } from "@reduxjs/toolkit";
-import { alphadayApi, coingeckoApi, zapperApi, ipApi } from "../services";
+import {
+    alphadayApi,
+    coingeckoApi,
+    zapperApi,
+    ipApi,
+    blobsApi,
+} from "../services";
 import searchReducer from "./slices/search";
 import uiReducer from "./slices/ui";
 import userReducer from "./slices/user";
@@ -18,6 +24,7 @@ export const rootReducer = combineReducers({
     [coingeckoApi.reducerPath]: coingeckoApi.reducer,
     [zapperApi.reducerPath]: zapperApi.reducer,
     [ipApi.reducerPath]: ipApi.reducer,
+    [blobsApi.reducerPath]: blobsApi.reducer,
 });
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/packages/frontend/src/api/store/store.ts
+++ b/packages/frontend/src/api/store/store.ts
@@ -13,7 +13,13 @@ import {
 import storage from "redux-persist/lib/storage";
 // import { setupListeners } from '@reduxjs/toolkit/query'
 import CONFIG from "src/config";
-import { alphadayApi, coingeckoApi, zapperApi, ipApi } from "../services";
+import {
+    alphadayApi,
+    coingeckoApi,
+    zapperApi,
+    ipApi,
+    blobsApi,
+} from "../services";
 import migrations from "./migrations";
 import { rootReducer, RootState as ReducerState } from "./reducer";
 
@@ -27,6 +33,7 @@ const persistConfig = {
         coingeckoApi.reducerPath,
         zapperApi.reducerPath,
         ipApi.reducerPath,
+        blobsApi.reducerPath,
     ],
 };
 
@@ -57,7 +64,8 @@ export const store = configureStore({
             .concat(alphadayApi.middleware)
             .concat(coingeckoApi.middleware)
             .concat(zapperApi.middleware)
-            .concat(ipApi.middleware),
+            .concat(ipApi.middleware)
+            .concat(blobsApi.middleware),
 });
 
 export const persistor = persistStore(store);

--- a/packages/frontend/src/components/uniswap/SwapModule.tsx
+++ b/packages/frontend/src/components/uniswap/SwapModule.tsx
@@ -1,5 +1,7 @@
 import { FC } from "react";
+import { ModuleLoader } from "@alphaday/ui-kit";
 import { SwapWidget, Theme, darkTheme } from "@uniswap/widgets";
+import CONFIG from "src/config";
 import ModuleDisclaimer from "../module-disclaimer/ModuleDisclaimer";
 import "./SwapModule.scss";
 
@@ -14,11 +16,14 @@ interface IProps {
     theme: Theme;
     termsOfService: string;
     showToS: boolean;
+    tokenList: string | undefined;
     /**
      * handler to call when user accepts terms of service
      */
     onAcceptToS: () => void;
 }
+
+const DEFAULT_HEIGHT = CONFIG.WIDGETS.COMMON.DEFAULT_WIDGET_HEIGHT;
 
 const SwapModule: FC<IProps> = ({
     config,
@@ -26,7 +31,9 @@ const SwapModule: FC<IProps> = ({
     showToS,
     termsOfService,
     onAcceptToS,
+    tokenList,
 }) => {
+    if (!tokenList) return <ModuleLoader $height={`${DEFAULT_HEIGHT}px`} />;
     return (
         <div className="uniswap-widget">
             <ModuleDisclaimer
@@ -39,6 +46,7 @@ const SwapModule: FC<IProps> = ({
                 width="100%"
                 convenienceFee={config.convenienceFee}
                 convenienceFeeRecipient={config.convenienceFeeRecipient}
+                tokenList={tokenList}
             />
         </div>
     );

--- a/packages/frontend/src/config/backend.ts
+++ b/packages/frontend/src/config/backend.ts
@@ -13,6 +13,7 @@ const API_V0 = {
         RESPONSE_LIMIT: 20,
     },
     API_BASE_URL: import.meta.env.VITE_API_BASE_URL,
+    BLOBS_URL: import.meta.env.VITE_STORAGE_BUCKET_URL,
     ROUTES: {
         ACTIVITY_LOG: {
             BASE: "activity_log",

--- a/packages/frontend/src/containers/uniswap/SwapContainer.tsx
+++ b/packages/frontend/src/containers/uniswap/SwapContainer.tsx
@@ -1,5 +1,6 @@
 import { FC } from "react";
 import { Theme, darkTheme } from "@uniswap/widgets";
+import { useGetTokensListQuery } from "src/api/services";
 import { setAcceptedSwapToS } from "src/api/store";
 import { useAppSelector, useAppDispatch } from "src/api/store/hooks";
 import { Logger } from "src/api/utils/logging";
@@ -22,6 +23,8 @@ const SwapContainer: FC<IModuleContainer> = () => {
         dispatch(setAcceptedSwapToS(true));
     };
 
+    const { data: tokenList } = useGetTokensListQuery();
+
     const theme: Theme = {
         ...darkTheme,
         fontFamily: "",
@@ -40,6 +43,7 @@ const SwapContainer: FC<IModuleContainer> = () => {
             showToS={!acceptedSwapToS}
             termsOfService={TermsOfService}
             onAcceptToS={acceptToS}
+            tokenList={tokenList}
         />
     );
 };


### PR DESCRIPTION
By default the widget calls `https://ipfs.io/ipns/tokens.uniswap.org` to retrieve this list but for some reason that call was returning a CORS error. An easy work around is to just provide the list directly as a prop.