### PR TITLE
fix: Remove empty horizontal space in the app

### DIFF
--- a/packages/frontend/src/containers/search/HeaderSearchContainer.tsx
+++ b/packages/frontend/src/containers/search/HeaderSearchContainer.tsx
@@ -188,6 +188,7 @@ const HeaderSearchContainer: FC = () => {
                         setSearchState(e);
                     }, 500)}
                     placeholder={translate("navigation.searchBarPlaceholder")}
+                    hideFeedback
                     initialSearchValues={
                         keywordSearchList === undefined
                             ? []

--- a/packages/ui-kit/src/components/search/Searchbar.tsx
+++ b/packages/ui-kit/src/components/search/Searchbar.tsx
@@ -154,6 +154,7 @@ export interface ISearchProps<Option = unknown> {
     closeMenuOnSelect?: boolean;
     updateSearch?: boolean;
     autoFocus?: boolean;
+    hideFeedback?: boolean;
     isFetchingKeywordResults?: boolean;
     isFetchingTrendingKeywordResults?: boolean;
     showBackdrop?: boolean;
@@ -184,6 +185,7 @@ export const SearchBar = <T,>({
     closeMenuOnSelect = false,
     updateSearch = true,
     autoFocus = false,
+    hideFeedback = false,
     componentClassNames,
     customComponents,
     isFetchingKeywordResults,
@@ -312,7 +314,7 @@ export const SearchBar = <T,>({
             {isFocused && showBackdrop && (
                 <div className="bg-black w-full h-full top-0 left-0 fixed opacity-40" />
             )}
-            <Feedback message={message} />
+            {!hideFeedback && <Feedback message={message} />}
             <Select
                 onFocus={() => setIsFocused(true)}
                 onBlur={() => setIsFocused(false)}


### PR DESCRIPTION
This happens when the boards library is open. The feedback (which we do not use in the header searchbar) takes up full screen width hence more space to the right because the searchbar is in the middle. [Notion](https://www.notion.so/Scrolling-to-the-right-of-the-page-on-Alphaday-exposes-blank-page-V-3-2-2-beta-Alpha-prod-1a84bd96c748800bab10feef645a09e2?pvs=4)