### PR TITLE
fix: Tutorial Count always shows Zero

### DIFF
--- a/packages/frontend/src/api/hooks/useTutorial.ts
+++ b/packages/frontend/src/api/hooks/useTutorial.ts
@@ -135,7 +135,7 @@ export const useTutorial: () => ITutorial = () => {
                     ? // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
                       allowedTutorials.indexOf(currentTutorialTip) + 1
                     : 1
-            }/${tutorials.length - 1}`,
+            }/${allowedTutorials.length - 1}`,
         },
     };
 };


### PR DESCRIPTION
## Before
<img width="500" alt="Screenshot 2025-04-28 at 16 48 46" src="https://github.com/user-attachments/assets/e628ef22-b9d0-4321-aceb-41e4b19aec56" />

## After
<img width="430" alt="Screenshot 2025-04-28 at 16 49 10" src="https://github.com/user-attachments/assets/b2f2ef7d-18c7-486b-a525-58ef1192e169" />
