### PR TITLE
fix: Search All Coin Tags For Matching Search Tags

### DIFF
--- a/packages/frontend/src/containers/kasandra/KasandraContainer.tsx
+++ b/packages/frontend/src/containers/kasandra/KasandraContainer.tsx
@@ -172,7 +172,9 @@ const KasandraContainer: FC<IModuleContainer> = ({ moduleData }) => {
         ) {
             const newMarketFromSearch = kasandraCoins.find((marketMeta) => {
                 // marketMeta.tags can be [] (an empty array)
-                return marketMeta.tags?.[0]?.id === lastSelectedKeyword.tag.id;
+                return marketMeta.tags?.find(
+                    (t) => t.id === lastSelectedKeyword.tag.id
+                );
             });
             if (newMarketFromSearch) {
                 handleSelectedMarket(newMarketFromSearch);

--- a/packages/frontend/src/containers/market/MarketContainer.tsx
+++ b/packages/frontend/src/containers/market/MarketContainer.tsx
@@ -147,7 +147,9 @@ const MarketContainer: FC<IModuleContainer> = ({ moduleData }) => {
         ) {
             const newMarketFromSearch = coinsData.find((marketMeta) => {
                 // marketMeta.tags can be [] (an empty array)
-                return marketMeta.tags?.[0]?.id === lastSelectedKeyword.tag.id;
+                return marketMeta.tags?.find(
+                    (t) => t.id === lastSelectedKeyword.tag.id
+                );
             });
             if (newMarketFromSearch) {
                 handleSelectedMarket(newMarketFromSearch);


### PR DESCRIPTION
We were just serching the first coin tag for a match instead of the entire array of tags.