### PR TITLE
fix: Kasandra Chart height

### DIFF
--- a/packages/frontend/src/components/kasandra/LineChart.tsx
+++ b/packages/frontend/src/components/kasandra/LineChart.tsx
@@ -422,7 +422,7 @@ const LineChart: FC<IProps> = memo(function LineChart({
 
     if (isLoading) {
         return (
-            <div className="flex w-full h-[200px] items-center justify-center">
+            <div className="flex w-full h-[340px] items-center justify-center">
                 <Spinner size="sm" />
             </div>
         );
@@ -436,7 +436,7 @@ const LineChart: FC<IProps> = memo(function LineChart({
     return (
         <div
             className={twMerge(
-                "w-full h-[200px] [&>div]:-mx-[10px] two-col:h-[354px] line-chart",
+                "w-full [&>div]:-mx-[10px] h-[354px] line-chart",
                 "[&_.apexcharts-svg]:h-[404px] [&_.apexcharts-xaxis-annotations_line[id^='SvgjsLine'][stroke='var(--alpha-primary)']]:scale-y-[1.2]"
             )}
         >

--- a/packages/frontend/src/containers/kasandra/KasandraContainer.tsx
+++ b/packages/frontend/src/containers/kasandra/KasandraContainer.tsx
@@ -199,7 +199,7 @@ const KasandraContainer: FC<IModuleContainer> = ({ moduleData }) => {
     }, [lastSelectedKeyword, kasandraCoins, tags, handleSelectedMarket]);
 
     const contentHeight = useMemo(() => {
-        return `${WIDGET_HEIGHT}px`;
+        return `${WIDGET_HEIGHT - 55}px`;
     }, [WIDGET_HEIGHT]);
 
     return (

--- a/packages/frontend/src/pages/index.tsx
+++ b/packages/frontend/src/pages/index.tsx
@@ -372,7 +372,7 @@ function BasePage({ isFullsize }: { isFullsize: boolean | undefined }) {
                                         marginTop:
                                             kasandraModuleData &&
                                             (colIndex === 0 || colIndex === 1)
-                                                ? `${WIDGETS.KASANDRA.WIDGET_HEIGHT}px`
+                                                ? `${((WIDGETS.KASANDRA.WIDGET_HEIGHT as number) || 0) + 14}px`
                                                 : "0px",
                                     }}
                                 >


### PR DESCRIPTION
- Fix the height for two column screen
- Fix the height while loading content
<img width="688" height="562" alt="Screenshot 2025-07-16 at 13 57 03" src="https://github.com/user-attachments/assets/e76aa6d4-3d84-4ebc-9cd7-b94d30304996" />
