### PR TITLE
chore: Show Red Color lines when Kasandra History Charts Are Negative

### DIFF
--- a/packages/frontend/src/components/kasandra/LineChart.tsx
+++ b/packages/frontend/src/components/kasandra/LineChart.tsx
@@ -1,5 +1,5 @@
 import { FC, memo, useCallback, useMemo, useState } from "react";
-import { ApexAreaChart, Spinner, twMerge } from "@alphaday/ui-kit";
+import { ApexAreaChart, Spinner, themeColors, twMerge } from "@alphaday/ui-kit";
 import { useTranslation } from "react-i18next";
 import { EPredictionCase, TChartRange } from "src/api/types";
 import { ENumberStyle, formatNumber } from "src/api/utils/format";
@@ -113,6 +113,12 @@ const LineChart: FC<IProps> = memo(function LineChart({
         selectedChartRange
     );
     const lastHistoryDataPoint = historyData[historyData.length - 1];
+    const startPrice = historyData[0][1];
+    const lastPrice = historyData[historyData.length - 1][1];
+    const historyColor =
+        lastPrice > startPrice || lastPrice === startPrice
+            ? themeColors.success
+            : themeColors.secondaryOrangeSoda;
 
     const chartSeries = useMemo(() => {
         const createSeries = (name: string, data: number[][]) => ({
@@ -200,7 +206,7 @@ const LineChart: FC<IProps> = memo(function LineChart({
 
     const seriesColors = useMemo(() => {
         const colors = [
-            "var(--alpha-green)",
+            historyColor,
             "var(--alpha-bullish)",
             "var(--alpha-base)",
             "var(--alpha-bearish)",
@@ -215,7 +221,7 @@ const LineChart: FC<IProps> = memo(function LineChart({
         }
 
         return colors;
-    }, [selectedCase]);
+    }, [historyColor, selectedCase]);
 
     const options = {
         chart: {


### PR DESCRIPTION
<img width="942" height="609" alt="Screenshot 2025-09-03 at 14 35 50" src="https://github.com/user-attachments/assets/3e6f9a49-42e8-4d07-b646-dc83825d4d1a" />
