### PR TITLE
fix: Use Same Color For History and Insights Points on Line Chart

### DIFF
--- a/packages/frontend/src/components/kasandra/LineChart.tsx
+++ b/packages/frontend/src/components/kasandra/LineChart.tsx
@@ -34,10 +34,11 @@ const generatePoints = (
     data: [number, number][],
     seriesIndex: 0 | 1 | 2 | 3,
     selectedTimestamp: number | undefined,
-    onSelectDataPoint: (dataPoint: number) => void
+    onSelectDataPoint: (dataPoint: number) => void,
+    historyColor: string
 ) => {
     const seriesIndexColorMap = {
-        0: "#6dd230",
+        0: historyColor,
         1: "#6dd230", // bullish
         2: "#cdd230", // base
         3: "#f45532", // bearish
@@ -178,10 +179,11 @@ const LineChart: FC<IProps> = memo(function LineChart({
                 data,
                 seriesIndex,
                 selectedTimestamp,
-                onSelectDataPoint
+                onSelectDataPoint,
+                historyColor
             );
         },
-        [selectedTimestamp, onSelectDataPoint]
+        [selectedTimestamp, onSelectDataPoint, historyColor]
     );
 
     const points = useMemo(() => {


### PR DESCRIPTION
<img width="946" height="603" alt="Screenshot 2025-09-08 at 11 51 10" src="https://github.com/user-attachments/assets/5ae33e86-7a3c-4849-9220-bbc91197c8cd" />
<img width="945" height="608" alt="Screenshot 2025-09-08 at 11 52 11" src="https://github.com/user-attachments/assets/46fe5787-b018-421b-a970-c101ac147693" />
