### PR TITLE
fix: Avoid Circular Depenedency

### DIFF
--- a/packages/frontend/src/api/utils/layoutUtils.ts
+++ b/packages/frontend/src/api/utils/layoutUtils.ts
@@ -2,43 +2,16 @@ import { useMemo } from "react";
 import { DraggingStyle, NotDraggingStyle } from "react-beautiful-dnd";
 import { TCachedView, TUserViewWidget } from "src/api/types";
 import { Logger } from "src/api/utils/logging";
-import ImageContainer from "src/containers/image/ImageContainer";
-import KasandraContainer from "src/containers/kasandra/KasandraContainer";
-import MarketHeatmapContainer from "src/containers/market-heatmap/MarketHeatmapContainer";
-import { deviceBreakpoints } from "src/globalStyles/breakpoints";
+import {
+    deviceBreakpoints,
+    twoColWidgetMaxWidths,
+} from "src/globalStyles/breakpoints";
 import CONFIG from "src/config";
-import { ETemplateNameRegistry } from "src/constants";
 
 const { Z_INDEX_REGISTRY } = CONFIG.UI;
-const { WIDGETS } = CONFIG;
+const { TWO_COL_WIDGETS } = CONFIG;
 
 const { singleCol, twoCol, threeCol, fourCol } = deviceBreakpoints;
-
-export const TWO_COL_WIDGET_MAX_WIDTHS = {
-    tiny: 1167, // not visble because of superfeed
-    singleCol: 1167, // not visible because of superfeed
-    twoCol: 1167,
-    threeCol: 1259,
-    fourCol: 1347,
-};
-
-export const TWO_COL_WIDGETS_CONFIG = {
-    image: {
-        templateName: ETemplateNameRegistry.Image,
-        Container: ImageContainer,
-        widgetConfig: WIDGETS.IMAGE,
-    },
-    kasandra: {
-        templateName: ETemplateNameRegistry.Kasandra,
-        Container: KasandraContainer,
-        widgetConfig: WIDGETS.KASANDRA,
-    },
-    marketHeatmap: {
-        templateName: ETemplateNameRegistry.MarketHeatmap,
-        Container: MarketHeatmapContainer,
-        widgetConfig: WIDGETS.MARKET_HEATMAP,
-    },
-} as const;
 
 /**
  * Heads up: layout is in the form (col #, row #) or (x, y), starting from the
@@ -277,7 +250,7 @@ export const recomputeWidgetsPos = (
 };
 
 export const getTwoColWidgetTemplateSlugs = () => {
-    return Object.values(TWO_COL_WIDGETS_CONFIG).map(
+    return Object.values(TWO_COL_WIDGETS).map(
         (config) => `${config.templateName.toLowerCase()}_template`
     );
 };
@@ -288,7 +261,7 @@ export const useTwoColWidgets = (selectedView: TCachedView | undefined) => {
         const twoColWidgetSlugs = getTwoColWidgetTemplateSlugs();
         const widgets: Record<string, TUserViewWidget> = {};
 
-        Object.entries(TWO_COL_WIDGETS_CONFIG).forEach(([key, config]) => {
+        Object.entries(TWO_COL_WIDGETS).forEach(([key, config]) => {
             const templateSlug = `${config.templateName.toLowerCase()}_template`;
             const widgetData = selectedView?.data.widgets.find(
                 (w: TUserViewWidget) => w.widget.template.slug === templateSlug
@@ -304,15 +277,15 @@ const getMaxWidthForScreenSize = (windowWidth: number): number => {
     const colType = getColType(windowWidth);
     switch (colType) {
         case EColumnType.SingleCol:
-            return TWO_COL_WIDGET_MAX_WIDTHS.singleCol;
+            return twoColWidgetMaxWidths.singleCol;
         case EColumnType.TwoCol:
-            return TWO_COL_WIDGET_MAX_WIDTHS.twoCol;
+            return twoColWidgetMaxWidths.twoCol;
         case EColumnType.ThreeCol:
-            return TWO_COL_WIDGET_MAX_WIDTHS.threeCol;
+            return twoColWidgetMaxWidths.threeCol;
         case EColumnType.FourCol:
-            return TWO_COL_WIDGET_MAX_WIDTHS.fourCol;
+            return twoColWidgetMaxWidths.fourCol;
         default:
-            return TWO_COL_WIDGET_MAX_WIDTHS.twoCol;
+            return twoColWidgetMaxWidths.twoCol;
     }
 };
 
@@ -324,7 +297,7 @@ export const calculateTwoColWidgetsHeight = (
     let totalHeight = 0;
     const defaultMarginBottom = 14;
 
-    Object.entries(TWO_COL_WIDGETS_CONFIG).forEach(([key, config]) => {
+    Object.entries(TWO_COL_WIDGETS).forEach(([key, config]) => {
         if (widgets[key]) {
             if (collapsedStates[key]) {
                 totalHeight +=

--- a/packages/frontend/src/config/config.ts
+++ b/packages/frontend/src/config/config.ts
@@ -15,7 +15,7 @@ import {
 import UI_CONFIG from "./ui";
 import USER_CONFIG from "./user";
 import VIEWS_CONFIG from "./views";
-import WIDGETS_CONFIG from "./widgets";
+import { WIDGETS_CONFIG, TWO_COL_WIDGETS_CONFIG } from "./widgets";
 
 // order is important here
 export enum EEnvironments {
@@ -86,6 +86,7 @@ const CONFIG = {
     ROUTING: ROUTING_CONFIG,
     UI: UI_CONFIG,
     WIDGETS: WIDGETS_CONFIG,
+    TWO_COL_WIDGETS: TWO_COL_WIDGETS_CONFIG,
     SUPERFEED: SUPERFEED_CONFIG,
     SEO: SEO_CONFIG,
     FIREBASE: FIREBASE_CONFIG,

--- a/packages/frontend/src/config/widgets.ts
+++ b/packages/frontend/src/config/widgets.ts
@@ -3,7 +3,7 @@ import { ETemplateNameRegistry } from "src/constants";
 
 const DEFAULT_WIDGET_HEIGHT = 500;
 
-const WIDGETS_CONFIG = {
+export const WIDGETS_CONFIG = {
     COMMON: {
         HEADER_HEIGHT: 42,
         DEFAULT_WIDGET_HEIGHT,
@@ -254,4 +254,20 @@ const WIDGETS_CONFIG = {
     },
 } as const;
 
-export default WIDGETS_CONFIG;
+export const TWO_COL_WIDGETS_CONFIG = {
+    image: {
+        templateSlug: "image_template",
+        templateName: ETemplateNameRegistry.Image,
+        widgetConfig: WIDGETS_CONFIG.IMAGE,
+    },
+    kasandra: {
+        templateSlug: "kasandra_template",
+        templateName: ETemplateNameRegistry.Kasandra,
+        widgetConfig: WIDGETS_CONFIG.KASANDRA,
+    },
+    marketHeatmap: {
+        templateSlug: "market_heatmap_template",
+        templateName: ETemplateNameRegistry.MarketHeatmap,
+        widgetConfig: WIDGETS_CONFIG.MARKET_HEATMAP,
+    },
+} as const;

--- a/packages/frontend/src/containers/image/ImageContainer.tsx
+++ b/packages/frontend/src/containers/image/ImageContainer.tsx
@@ -2,10 +2,8 @@ import { type FC, Suspense, useMemo } from "react";
 import { ModuleLoader } from "@alphaday/ui-kit";
 import { useWindowSize } from "src/api/hooks";
 import { TRemoteCustomData } from "src/api/services";
-import {
-    getColType,
-    TWO_COL_WIDGET_MAX_WIDTHS,
-} from "src/api/utils/layoutUtils";
+import { getColType } from "src/api/utils/layoutUtils";
+import { twoColWidgetMaxWidths } from "src/globalStyles/breakpoints";
 import CONFIG from "src/config";
 import type { IModuleContainer } from "src/types";
 import { ImageModule } from "../../components/image/ImageModule";
@@ -35,7 +33,7 @@ const ImageContainer: FC<IModuleContainer> = ({ moduleData }) => {
 
         if (aspectRatio && windowSize.width) {
             const colType = getColType(windowSize.width);
-            const maxWidth = TWO_COL_WIDGET_MAX_WIDTHS[colType];
+            const maxWidth = twoColWidgetMaxWidths[colType];
 
             const calculatedHeight = maxWidth / aspectRatio;
             return `${calculatedHeight}px`;

--- a/packages/frontend/src/pages/index.tsx
+++ b/packages/frontend/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, useMemo, useRef, memo } from "react";
+import { useCallback, useState, useMemo, useRef, memo, FC } from "react";
 import { DragDropContext, DropResult, Droppable } from "react-beautiful-dnd";
 import {
     useView,
@@ -24,7 +24,6 @@ import {
     recomputeWidgetsPos,
     getColType,
     EColumnType,
-    TWO_COL_WIDGETS_CONFIG,
     useTwoColWidgets,
     calculateTwoColWidgetsHeight,
 } from "src/api/utils/layoutUtils";
@@ -39,9 +38,9 @@ import WalletConnectionDialogContainer from "src/containers/dialogs/WalletConnec
 import { LanguageModalContainer } from "src/containers/LanguageModalContainer";
 import TutorialContainer from "src/containers/tutorial/TutorialContainer";
 import MainLayout from "src/layout/MainLayout";
-import { TTemplateSlug } from "src/types";
+import { TTemplateSlug, TEMPLATES_DICT, IModuleContainer } from "src/types";
 
-const { UI, VIEWS } = CONFIG;
+const { UI, VIEWS, TWO_COL_WIDGETS } = CONFIG;
 
 function BasePage({ isFullsize }: { isFullsize: boolean | undefined }) {
     const dispatch = useAppDispatch();
@@ -355,12 +354,16 @@ function BasePage({ isFullsize }: { isFullsize: boolean | undefined }) {
             >
                 <div className="two-col:grid-cols-2 relative three-col:grid-cols-3 four-col:grid-cols-4 grid w-full grid-cols-1 gap-5 px-4">
                     <div className="two-col:grid-cols-2 absolute three-col:grid-cols-3 four-col:grid-cols-4 grid w-full grid-cols-1 px-4">
-                        {Object.entries(TWO_COL_WIDGETS_CONFIG).map(
+                        {Object.entries(TWO_COL_WIDGETS).map(
                             ([key, config]) => {
                                 const moduleData = twoColWidgets[key];
                                 if (!moduleData) return null;
 
-                                const { Container } = config;
+                                const Container = TEMPLATES_DICT[
+                                    config.templateSlug
+                                ] as FC<IModuleContainer>;
+                                if (!Container) return null;
+
                                 return (
                                     <div key={key} className="col-span-2">
                                         <Container

--- a/packages/ui-kit/src/globalStyles/breakpoints.ts
+++ b/packages/ui-kit/src/globalStyles/breakpoints.ts
@@ -9,6 +9,14 @@ export const breakpoints = {
     FourColMaxWidth: 2725,
 };
 
+export const twoColWidgetMaxWidths = {
+    tiny: 1167, // not visble because of superfeed
+    singleCol: 1167, // not visible because of superfeed
+    twoCol: 1167,
+    threeCol: 1259,
+    fourCol: 1347,
+};
+
 export const deviceBreakpoints = {
     tiny: breakpoints.tiny,
     singleCol: breakpoints.SingleColMinWidth,


### PR DESCRIPTION
This causes infinite loops in a build

### Previous dependency chain
- ImageContainer → imports from layoutUtils
- layoutUtils → imports ImageContainer to use in TWO_COL_WIDGETS_CONFIG

### Current dependency chain

- ImageContainer → layoutUtils (for getColType)
- ImageContainer → breakpoints (for twoColWidgetMaxWidths)
- layoutUtils → breakpoints (for constants)
- layoutUtils → CONFIG (for widget configs, no container imports)