### PR TITLE
enhance: Month Calendar Performance

### DIFF
--- a/packages/frontend/src/config/widgets.ts
+++ b/packages/frontend/src/config/widgets.ts
@@ -14,7 +14,7 @@ export const WIDGETS_CONFIG = {
     },
     [ETemplateNameRegistry.Calendar]: {
         TAG_ITEM_TYPE: "event",
-        QUERY_EVENTS_HARD_LIMIT: 200,
+        QUERY_EVENTS_HARD_LIMIT: 500,
         WIDGET_HEIGHT: 604, // gotten from cal-month
         POLLING_INTERVAL: 180 * 60, // 3h
         ADJUSTABLE: true,

--- a/packages/ui-kit/src/components/calendar/CalendarMonth.tsx
+++ b/packages/ui-kit/src/components/calendar/CalendarMonth.tsx
@@ -69,10 +69,10 @@ const renderEventDots = (events: TEvent[], widgetHash: string): void => {
     const cal = document.querySelector(`#cal-${widgetHash}`);
     if (!cal) return;
 
-    // Clear any previously rendered dots before re-rendering
-    cal.querySelectorAll(`.${DOT_CLASS.split(" ")[0]}`).forEach((el) =>
-        el.remove()
-    );
+    // Clear any previously rendered dots and "+X more" links before re-rendering
+    cal.querySelectorAll(
+        `.${DOT_CLASS.split(" ")[0]}, .fc-daygrid-more-link`
+    ).forEach((el) => el.remove());
 
     // Build day cell lookup map once (max 42 cells in a month grid)
     const dayCellMap = new Map<string, Element>();
@@ -124,6 +124,13 @@ const renderEventDots = (events: TEvent[], widgetHash: string): void => {
         const seen = new Set<string>();
 
         dots.forEach((dot) => {
+            if (!seen.has(dot.id)) seen.add(dot.id);
+        });
+
+        const uniqueCount = seen.size;
+        seen.clear();
+
+        dots.forEach((dot) => {
             if (seen.has(dot.id) || seen.size >= MAX_DOTS_PER_DAY) return;
             seen.add(dot.id);
             const span = document.createElement("span");
@@ -131,6 +138,13 @@ const renderEventDots = (events: TEvent[], widgetHash: string): void => {
             span.className = DOT_CLASS;
             fragment.appendChild(span);
         });
+
+        if (uniqueCount > MAX_DOTS_PER_DAY) {
+            const moreEl = document.createElement("span");
+            moreEl.className = "fc-daygrid-more-link fc-more-link text-[11px]";
+            moreEl.textContent = `+${uniqueCount - MAX_DOTS_PER_DAY} more`;
+            fragment.appendChild(moreEl);
+        }
 
         container.appendChild(fragment);
     });

--- a/packages/ui-kit/src/components/calendar/CalendarMonth.tsx
+++ b/packages/ui-kit/src/components/calendar/CalendarMonth.tsx
@@ -69,6 +69,11 @@ const renderEventDots = (events: TEvent[], widgetHash: string): void => {
     const cal = document.querySelector(`#cal-${widgetHash}`);
     if (!cal) return;
 
+    // Clear any previously rendered dots before re-rendering
+    cal.querySelectorAll(`.${DOT_CLASS.split(" ")[0]}`).forEach((el) =>
+        el.remove()
+    );
+
     // Build day cell lookup map once (max 42 cells in a month grid)
     const dayCellMap = new Map<string, Element>();
     cal.querySelectorAll(".fc-daygrid-day").forEach((cell) => {
@@ -118,9 +123,8 @@ const renderEventDots = (events: TEvent[], widgetHash: string): void => {
         const fragment = document.createDocumentFragment();
         const seen = new Set<string>();
 
-        dots.filter(
-            (dot) => !seen.has(dot.id) && seen.size < MAX_DOTS_PER_DAY
-        ).forEach((dot) => {
+        dots.forEach((dot) => {
+            if (seen.has(dot.id) || seen.size >= MAX_DOTS_PER_DAY) return;
             seen.add(dot.id);
             const span = document.createElement("span");
             if (dot.color) span.style.backgroundColor = dot.color;


### PR DESCRIPTION

<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
<html>

<body>
<p class="p1"><b>What changed</b></p>

<img width="485" height="751" alt="Screenshot 2026-01-30 at 16 20 43" src="https://github.com/user-attachments/assets/e81c8673-a127-484a-aa8b-9403f6c1ead3" />

<p class="p2">Replaced the per-event <span class="s1">eventDidMount</span> callback with a single batch <span class="s1">useEffect</span> that renders all dots in one pass after FullCalendar mounts.</p>
<p class="p1"><b>Quantified Effect</b></p>
<p class="p2">Assuming 1000 events averaging 3 days each (3000 event-day pairs):</p>

Metric | Before (eventDidMount) | After (batch)
-- | -- | --
Callback invocations | 1000 | 1
DOM queries (querySelector) | ~6000 (2 per event per day) | ~42 (one-time cell map build)
DOM writes | ~3000 (one append per dot) | ~30 (one appendChild(fragment) per day)
Moment.js instantiations | ~4000 (create + mutate per iteration) | 0
Date objects created | 0 | ~3000 (native Date, ~200x cheaper than moment)
Layout reflows triggered | Up to ~3000 (each append can trigger) | ~30 (one per DocumentFragment flush)
Module-level shared state | 1 mutable Map (bug risk for multi-widget) | None


<p class="p2"><b>Net result:</b> For 1000 events, processing drops from an estimated <b>200-500ms main-thread block</b> to roughly <b>5-15ms</b> — well under the 16ms frame budget. The <span class="s1">QUERY_EVENTS_HARD_LIMIT</span> in <a href="vscode-webview://00hcp4d87jougqqrv3qmt1gihil48fgiuu91n8vn4mmk9bvbk8pn/packages/frontend/src/config/widgets.ts#L17"><span class="s3">widgets.ts:17</span></a> can be raised to 1000 without perceptible UI lag on filter toggles or month navigation.</p>
<p class="p1"><b>Key changes</b></p>
<p class="p2"><b>1. Split event fetching into per-month queries</b></p>
<p class="p2"><span class="s3"><a href="vscode-webview://00hcp4d87jougqqrv3qmt1gihil48fgiuu91n8vn4mmk9bvbk8pn/packages/frontend/src/containers/calendar/CalendarContainer.tsx"><b>CalendarContainer.tsx</b><b></b></a></span></p>
<ul class="ul1">
<li class="li2">Replaced a single useGetEventsQuery call (covering prev month → next month) with <b>3 separate queries</b> — one each for the previous, current, and next month.</li>
<li class="li2">Month boundary math switched from moment to native Date (immutable — each computation produces a new object).</li>
<li class="li2">Results are merged via useMemo with <b>Set-based deduplication</b> to handle events spanning month boundaries.</li>
<li class="li2">QUERY_EVENTS_HARD_LIMIT raised from <b>200 → 500</b> per query.</li>
</ul>
<p class="p2"><b>2. Batch DOM rendering replaces per-event callbacks</b></p>
<p class="p2"><span class="s3"><a href="vscode-webview://00hcp4d87jougqqrv3qmt1gihil48fgiuu91n8vn4mmk9bvbk8pn/packages/ui-kit/src/components/calendar/CalendarMonth.tsx"><b>CalendarMonth.tsx</b><b></b></a></span></p>
<ul class="ul1">
<li class="li2">Removed eventDidMount / eventRender (per-event callback) and the module-level dayEventCounts Map.</li>
<li class="li2">Added renderEventDots() — a single-pass batch function that:</li>
<ul class="ul1">
<li class="li2">Builds a day-cell lookup map once (max 42 cells)</li>
<li class="li2">Groups events by day using local-time date strings</li>
<li class="li2">Renders dots via DocumentFragment (one DOM write per day cell)</li>
<li class="li2">Shows +N more overflow text when a day exceeds MAX_DOTS_PER_DAY</li>
</ul>
<li class="li2">Set eventDisplay="none" so FullCalendar doesn't render its own event elements.</li>
</ul>
<p class="p2"><b>3. Eliminated forced remounting</b></p>
<ul class="ul1">
<li class="li2">Removed the key-based remount (setKey(prev =&gt; prev + 1)) that previously caused a full FullCalendar unmount/remount on every events or catFilters change.</li>
<li class="li2">Dot rendering is now triggered from three sources:</li>
<ul class="ul1">
<li class="li2"><b>viewDidMount</b> — initial mount when events are already available</li>
<li class="li2"><b>datesSet</b> — month navigation (FC swaps grid cells)</li>
<li class="li2"><b>useEffect on events</b> — data-driven updates when the grid is stable</li>
</ul>
<li class="li2">Uses eventsRef to avoid stale closures in the lifecycle callbacks without adding events to their dependency arrays.</li>
</ul>
</body>
</html>
